### PR TITLE
Use '| safe' to fix urls in menus

### DIFF
--- a/themes/after-dark/templates/index.html
+++ b/themes/after-dark/templates/index.html
@@ -49,7 +49,7 @@
                         {% for item in config.extra.after_dark_menu %}
                             <a itemprop="url"
                                class="{% if item.url | replace(from="$BASE_URL", to=config.base_url) == current_url %}active{% endif %}"
-                               href="{{ item.url | safe | replace(from="$BASE_URL", to=config.base_url) }}">
+                               href="{{ item.url | safe | replace(from="$BASE_URL", to=config.base_url) | safe }}">
                                 <span itemprop="name">{{ item.name }}</span></a>
                         {% endfor %}
                         </nav>


### PR DESCRIPTION
I noticed the theme also already had menu items that also needed this fix. I tacked it onto my pull request for the theme already.